### PR TITLE
support main branch

### DIFF
--- a/src/DotnetCIVersionProperties/ProjectVersionPropsWriter.cs
+++ b/src/DotnetCIVersionProperties/ProjectVersionPropsWriter.cs
@@ -22,7 +22,7 @@ namespace DotnetCIVersionProperties {
 			if( tag.Equals( $"v{ major }.{ minor }.{ patch }" ) ) {
 				versionSuffix = string.Empty;
 
-			} else if( branch.Equals( "master" ) ) {
+			} else if( branch.Equals( "master" ) || branch.Equals( "main" ) ) {
 				versionSuffix = $"rc.{ build }";
 
 			} else {

--- a/tests/DotnetCIVersionProperties.Tests/ProjectVersionPropsWriterTests.cs
+++ b/tests/DotnetCIVersionProperties.Tests/ProjectVersionPropsWriterTests.cs
@@ -59,7 +59,31 @@ namespace DotnetCIVersionProperties.Tests {
 					expectedProps: expectedProps
 				);
 		}
+		[Test]
+		public void MainBranch() {
 
+			const string expectedProps = @"<Project>
+	<PropertyGroup>
+		<VersionPrefix>10.6.8</VersionPrefix>
+		<VersionSuffix>rc.93</VersionSuffix>
+		<Version>10.6.8-rc.93</Version>
+		<AssemblyVersion>10.6.0.0</AssemblyVersion>
+		<FileVersion>10.6.8.93</FileVersion>
+		<InformationalVersion>10.6.8-rc.93+A94A8FE5CCB19BA61C4C0873D391E987982FBBD3</InformationalVersion>
+		<RepositoryBranch>main</RepositoryBranch>
+		<RepositoryCommit>A94A8FE5CCB19BA61C4C0873D391E987982FBBD3</RepositoryCommit>
+	</PropertyGroup>
+</Project>
+";
+			AssertWrite(
+					versionPrefix: new Version( 10, 6, 8 ),
+					branch: "main",
+					tag: string.Empty,
+					build: 93,
+					sha1: "A94A8FE5CCB19BA61C4C0873D391E987982FBBD3",
+					expectedProps: expectedProps
+				);
+		}
 		[Test]
 		public void ReleaseTag() {
 


### PR DESCRIPTION
* Allow all those swanky new repos with `main` branches to get that `rc` suffix as well (else it's all alpha/release like this guy - https://proget.d2l.dev/feeds/nuget/D2L.DevTools.DbBuilder/versions/all)